### PR TITLE
Use moment i18n months and weeks in the daypicker

### DIFF
--- a/addon/components/en-daypicker.js
+++ b/addon/components/en-daypicker.js
@@ -36,11 +36,11 @@ export default Component.extend(KeyboardHandler, {
 
   month: computed("activeDate", {
     get() {
-      let moments = Constants.months
+      let months = moment.months();
       let index = get(this, "activeDate").month()
 
       return {
-        name: moments[index],
+        name: months[index],
         index: index
       }
     }
@@ -117,7 +117,15 @@ export default Component.extend(KeyboardHandler, {
     }
   },
 
-  weekDays: Constants.weekdays,
+  weekDays: computed(function() {
+    const weekDays = moment.weekdays().map((day, index) => {
+      return {
+        abbr: moment.weekdaysShort()[index],
+        fullname: day
+      }
+    });
+    return weekDays;
+  }),
 
   didInsertElement() {
     this._super(...arguments)

--- a/addon/utils/constants.js
+++ b/addon/utils/constants.js
@@ -1,16 +1,3 @@
 export default {
-  weekdays: {
-    "Sun": "Sunday",
-    "Mon": "Monday",
-    "Tue": "Tuesday",
-    "Wed": "Wednesday",
-    "Thu": "Thursday",
-    "Fri": "Friday",
-    "Sat": "Saturday"
-  },
-
-  months: ["January", "February", "March", "April", "May", "June",
-    "July", "August", "September", "October", "November", "December"],
-
   defaultFormat: "MMM DD, YYYY"
 }

--- a/app/templates/components/en-daypicker.hbs
+++ b/app/templates/components/en-daypicker.hbs
@@ -9,13 +9,13 @@
 <div class="en-daypicker-month-wrapper">
   <div class="en-daypicker-month">
     <div class="en-daypicker-header">
-      {{#each-in weekDays as |abbr expanded|}}
+      {{#each weekDays as |weekDay|}}
         <div class="en-daypicker-header-day">
-          <abbr title="{{expanded}}">
-            {{abbr}}
+          <abbr title="{{weekDay.fullname}}">
+            {{weekDay.abbr}}
           </abbr>
         </div>
-      {{/each-in}}
+      {{/each}}
     </div>
 
     {{#each weeksArray as |week|}}

--- a/config/environment.js
+++ b/config/environment.js
@@ -2,5 +2,11 @@
 'use strict';
 
 module.exports = function(/* environment, appConfig */) {
-  return { };
+  return {
+    moment: {
+      // To cherry-pick specific locale support into your application.
+      // Full list of locales: https://github.com/moment/moment/tree/2.10.3/locale
+      includeLocales: ['en', 'fr']
+    }
+  };
 };


### PR DESCRIPTION
Instead of hardcoding the strings in English, we use moment to fetch week day names and month names so that if moment is configured with another locale, it's free!